### PR TITLE
V0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ This cookbook was tested for Aerospike v3.6.3.
 
 * `default['aerospike']['tarball_url']` (default: `auto`): aerospike tarball url
 
+* `default['aerospike']['checksum_verify']` (default: `true`): checking checksum of aerospike and amc tarballs/packages
+
 * `default['aerospike']['notify_restart']` (default: `true`): whether to restart aerospike service on configuration file change
 
 * `default['aerospike']['install_method']` (default: `tarball`): aerospike install method, options: tarball
@@ -231,6 +233,8 @@ This cookbook was tested for Aerospike v3.6.3.
 
 
 ## AMC Attributes
+
+* `default['aerospike']['amc']['version']` (default: `3.6.3`): amc version
 
 * `default['aerospike']['amc']['conf_dir']` (default: `/etc/amc/config`): amc config directory
 

--- a/attributes/amc.rb
+++ b/attributes/amc.rb
@@ -1,5 +1,6 @@
 default['aerospike']['amc']['conf_dir'] = '/etc/amc/config'
 default['aerospike']['amc']['log_dir'] = '/var/log/amc'
+default['aerospike']['amc']['version'] = '3.6.3'
 
 default['aerospike']['amc']['service_action'] = [:enable, :start]
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,4 +39,4 @@ default['aerospike']['mode']  = '0755'
 default['aerospike']['enable_test_namespace'] = true
 
 default['aerospike']['chef']['search'] = "role:aerospike-server AND chef_environment:#{node.chef_environment}"
-default['aerospike']['checksum_verify'] = false
+default['aerospike']['checksum_verify'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,3 +39,4 @@ default['aerospike']['mode']  = '0755'
 default['aerospike']['enable_test_namespace'] = true
 
 default['aerospike']['chef']['search'] = "role:aerospike-server AND chef_environment:#{node.chef_environment}"
+default['aerospike']['checksum_verify'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures aerospike-cluster'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vkhatri/chef-aerospike-cluster/issues'
 source_url 'https://github.com/vkhatri/chef-aerospike-cluster'
-version '0.1.3'
+version '0.1.4'
 
 %w(ubuntu centos amazon redhat fedora).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures aerospike-cluster'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vkhatri/chef-aerospike-cluster/issues'
 source_url 'https://github.com/vkhatri/chef-aerospike-cluster'
-version '0.1.4'
+version '0.1.5'
 
 %w(ubuntu centos amazon redhat fedora).each do |os|
   supports os

--- a/recipes/amc.rb
+++ b/recipes/amc.rb
@@ -37,9 +37,9 @@ case node['aerospike']['amc']['package_url']
 when 'auto'
   case node['aerospike']['install_edition']
   when 'community'
-    package_url = "http://www.aerospike.com/download/amc/#{node['aerospike']['version']}/artifact/#{package_url_suffix}"
+    package_url = "http://www.aerospike.com/download/amc/#{node['aerospike']['amc']['version']}/artifact/#{package_url_suffix}"
   when 'enterprise'
-    package_url = "http://#{node['aerospike']['enterprise']['username']}:#{node['aerospike']['enterprise']['password']}@www.aerospike.com/enterprise/download/amc/#{node['aerospike']['version']}/artifact/#{package_url_suffix}"
+    package_url = "http://#{node['aerospike']['enterprise']['username']}:#{node['aerospike']['enterprise']['password']}@www.aerospike.com/enterprise/download/amc/#{node['aerospike']['amc']['version']}/artifact/#{package_url_suffix}"
   else
     raise "invalid aerospike edition, valid are 'community, enterprise'"
   end
@@ -47,8 +47,8 @@ else
   package_url = node['aerospike']['amc']['package_url']
 end
 
-package_checksum = amc_package_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version'], package_url_suffix) if node['aerospike']['checksum_verify']
-package_file = ::File.join(node['aerospike']['parent_dir'], "aerospike-amc-#{node['aerospike']['install_edition']}-#{node['aerospike']['version']}#{package_suffix}.#{node['kernel']['machine']}.#{package_type}")
+package_checksum = amc_package_sha256sum(node['aerospike']['install_edition'], node['aerospike']['amc']['version'], package_url_suffix) if node['aerospike']['checksum_verify']
+package_file = ::File.join(node['aerospike']['parent_dir'], "aerospike-amc-#{node['aerospike']['install_edition']}-#{node['aerospike']['amc']['version']}#{package_suffix}.#{node['kernel']['machine']}.#{package_type}")
 
 # download tarball
 if node['aerospike']['install_edition'] == 'enterprise'
@@ -74,7 +74,7 @@ node['aerospike']['amc']['packages'].each do |p|
   package p
 end
 
-package "aerospike-amc-#{node['aerospike']['install_edition']}-#{node['aerospike']['version']}#{package_suffix}" do
+package "aerospike-amc-#{node['aerospike']['install_edition']}-#{node['aerospike']['amc']['version']}#{package_suffix}" do
   source package_file
   provider Chef::Provider::Package::Dpkg if node['platform_family'] == 'debian'
 end

--- a/recipes/amc.rb
+++ b/recipes/amc.rb
@@ -47,7 +47,7 @@ else
   package_url = node['aerospike']['amc']['package_url']
 end
 
-package_checksum = amc_package_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version'], package_url_suffix)
+package_checksum = amc_package_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version'], package_url_suffix) if node['aerospike']['checksum_verify']
 package_file = ::File.join(node['aerospike']['parent_dir'], "aerospike-amc-#{node['aerospike']['install_edition']}-#{node['aerospike']['version']}#{package_suffix}.#{node['kernel']['machine']}.#{package_type}")
 
 # download tarball
@@ -64,7 +64,7 @@ if node['aerospike']['install_edition'] == 'enterprise'
 else
   remote_file package_file do
     source package_url
-    checksum package_checksum
+    checksum package_checksum if node['aerospike']['checksum_verify']
     owner node['aerospike']['user']
     group node['aerospike']['group']
   end

--- a/recipes/dependency.rb
+++ b/recipes/dependency.rb
@@ -18,3 +18,4 @@
 #
 
 # TODO: add package dependency
+include_recipe 'aerospike-cluster::user'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -41,7 +41,7 @@ else
 end
 
 package_file = ::File.join(node['aerospike']['parent_dir'], "aerospike-server-#{node['aerospike']['install_edition']}-#{node['aerospike']['version']}-#{node['aerospike']['package_suffix']}.tgz")
-package_checksum = package_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version'], node['aerospike']['package_suffix'])
+package_checksum = package_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version'], node['aerospike']['package_suffix']) if node['aerospike']['checksum_verify']
 
 # download tarball
 if node['aerospike']['install_edition'] == 'enterprise'
@@ -57,7 +57,7 @@ if node['aerospike']['install_edition'] == 'enterprise'
 else
   remote_file package_file do
     source package_url
-    checksum package_checksum
+    checksum package_checksum if node['aerospike']['checksum_verify']
     owner node['aerospike']['user']
     group node['aerospike']['group']
     not_if { ::File.exist?(::File.join(node['aerospike']['source_dir'], 'asinstall')) }

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -28,8 +28,6 @@ tarball_url = if node['aerospike']['tarball_url'] == 'auto'
 tarball_file = ::File.join(node['aerospike']['parent_dir'], "aerospike-server-community-#{node['aerospike']['version']}.tar.gz")
 tarball_checksum = tarball_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version']) if node['aerospike']['checksum_verify']
 
-include_recipe 'aerospike-cluster::user'
-
 [node['aerospike']['source_dir']
 ].each do |dir|
   directory dir do

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -26,7 +26,7 @@ tarball_url = if node['aerospike']['tarball_url'] == 'auto'
               end
 
 tarball_file = ::File.join(node['aerospike']['parent_dir'], "aerospike-server-community-#{node['aerospike']['version']}.tar.gz")
-tarball_checksum = tarball_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version'])
+tarball_checksum = tarball_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version']) if node['aerospike']['checksum_verify']
 
 include_recipe 'aerospike-cluster::user'
 
@@ -50,7 +50,7 @@ end
 # download tarball
 remote_file tarball_file do
   source tarball_url
-  checksum tarball_checksum
+  checksum tarball_checksum if node['aerospike']['checksum_verify']
   owner node['aerospike']['user']
   group node['aerospike']['group']
   not_if { ::File.exist?(::File.join(node['aerospike']['source_dir'], 'aerospike-server', 'bin', 'aerospike')) }


### PR DESCRIPTION
I added an option for disabling checksum as it is hard coded in v0.1.4. And added support for a different AMC version, because for example latest aerospike version is 3.7.5.1. But AMC only is 3.6.8.
Updated README with new options.
More details in commits comment.

P.S. If you're interested I can merge my simple serverspec tests from my wrapper cookbook.
