### PR TITLE
V0.1.8

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -79,19 +79,16 @@ suites:
   - name: multicast
     run_list:
       - recipe[aerospike-cluster::default]
+      - recipe[aerospike-cluster::cluster]
     attributes:
       aerospike:
         checksum_verify: false
         install_method: 'package'
         version: '3.8.2.3'
-        chef:
-          search: ""
         config:
           network:
             heartbeat:
               mode: multicast
               address: '224.2.2.4'
-              port: 9918
         amc:
           version: '3.6.8'
-          host: ''

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 branches:
   only:
     - master
-    - /^(i:ci)-\d\.\d\.\d/
+    - /^(i:ci)-v.*$/
 
 language: ruby
 bundler_args: --without integration development

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 services:
   - docker
 
+branches:
+  only:
+    - master
+    - /^(i:ci)-\d\.\d\.\d/
+
 language: ruby
 bundler_args: --without integration development
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 branches:
   only:
     - master
-    - /^(i:ci)-v.*$/
+    - /.*-alpha.*/
 
 language: ruby
 bundler_args: --without integration development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This file is used to list changes made in each version of the aerospike-cluster 
 
 - [Oleksandr Sakharchuk](https://github.com/pioneerit):
   - Remove cloning resource attributes from prior resource (CHEF-3694)
-  - Permanent fix for #8 - remote_file for enterprise edition with authentication
-  - After PR #12 attribute `mesh-seed-address-port` not needed.
+  - Permanent fix for [#8](https://github.com/vkhatri/chef-aerospike-cluster/issues/8) - remote_file for enterprise edition with authentication
+  - After PR [#12](https://github.com/vkhatri/chef-aerospike-cluster/pull/12) attribute `mesh-seed-address-port` not needed.
   - Update cluster.rb recipe for default value and support chef-solo if possible
   - Restart `amc` applicatoin if `aerospike` was restarted
   - test update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,47 +2,58 @@ aerospike-cluster CHANGELOG
 ===========================
 
 This file is used to list changes made in each version of the aerospike-cluster cookbook.
-0.1.7
------
+0.1.8 (01/06/2015)
+------------------
 
-- Oleksandr Sakharchuk - Add test suit case for multicast mode cluster
+- [Oleksandr Sakharchuk](https://github.com/pioneerit):
+  - Remove cloning resource attributes from prior resource (CHEF-3694)
+  - Permanent fix for #8 - remote_file for enterprise edition with authentication
+  - After PR #12 attribute `mesh-seed-address-port` not needed.
+  - Update cluster.rb recipe for default value and support chef-solo if possible
+  - Restart `amc` applicatoin if `aerospike` was restarted
+  - test update
 
-- Oleksandr Sakharchuk - Update `aerospike-cluster::cluster` to ignore `mesh` configuration for `mode: multicast` which cause an error
+0.1.7 (31/05/2015)
+------------------
 
-0.1.6
------
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add test suit case for multicast mode cluster
 
-- Oleksandr Sakharchuk - Add RHEL7 support, after [last Aerospike release](http://www.aerospike.com/download/server/notes.html#3.8.2.1)
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update `aerospike-cluster::cluster` to ignore `mesh` configuration for `mode: multicast` which cause an error
 
-- Oleksandr Sakharchuk - Add Ubuntu-14.04 support
+0.1.6 (26/05/2015)
+------------------
 
-- Oleksandr Sakharchuk - Update kitchen config
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add RHEL7 support, after [last Aerospike release](http://www.aerospike.com/download/server/notes.html#3.8.2.1)
 
-- Oleksandr Sakharchuk - Add integration tests for old (3.6.3) and latest (3.8.2.3)
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add Ubuntu-14.04 support
 
-- Oleksandr Sakharchuk - Update kitchen test to docker
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update kitchen config
 
-- Oleksandr Sakharchuk - Update travis-ci to use docker
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add integration tests for old (3.6.3) and latest (3.8.2.3)
 
-0.1.5
------
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update kitchen test to docker
 
-- Oleksandr Sakharchuk - Fix foodcritic
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update travis-ci to use docker
 
-- Oleksandr Sakharchuk - Fix a typo with attribure for package_url
+0.1.5 (11/05/2016)
+------------------
 
-- Oleksandr Sakharchuk - Added user cookbook as dependency
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fix foodcritic
 
-- Oleksandr Sakharchuk - Fix travis and typo
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fix a typo with attribure for package_url
 
-- Oleksandr Sakharchuk - Add atrribute to disable cheksum checking
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Added user cookbook as dependency
 
-- Oleksandr Sakharchuk - Added support for amc version attribute
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fix travis and typo
 
-- Oleksandr Sakharchuk - Fixed recipes dependencies
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add atrribute to disable cheksum checking
 
-0.1.3
------
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Added support for amc version attribute
+
+- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fixed recipes dependencies
+
+0.1.3 (28/12/2015)
+------------------
 
 - Blair Hamilton - adding clustering via chef server
 
@@ -52,8 +63,8 @@ This file is used to list changes made in each version of the aerospike-cluster 
 
 - Virender Khatri - fix rubocop #14
 
-0.1.2
------
+0.1.2 (31/10/2015)
+------------------
 
 - Virender Khatri - #7, added enterprise edition support
 
@@ -61,13 +72,13 @@ This file is used to list changes made in each version of the aerospike-cluster 
 
 - Virender Khatri - #3, make test namespace setup optional
 
-0.1.1
------
+0.1.1 (26/10/2015)
+------------------
 
 - Virender Khatri - #1, added package installation support
 
-0.1.0
------
+0.1.0 (24/10/2015)
+------------------
 
 - Virender Khatri - Initial release of aerospike-cluster
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ aerospike-cluster CHANGELOG
 ===========================
 
 This file is used to list changes made in each version of the aerospike-cluster cookbook.
+
 0.1.8 (01/06/2015)
 ------------------
 
@@ -16,71 +17,60 @@ This file is used to list changes made in each version of the aerospike-cluster 
 0.1.7 (31/05/2015)
 ------------------
 
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add test suit case for multicast mode cluster
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update `aerospike-cluster::cluster` to ignore `mesh` configuration for `mode: multicast` which cause an error
+- [Oleksandr Sakharchuk](https://github.com/pioneerit):
+  - Add test suit case for multicast mode cluster
+  - Update `aerospike-cluster::cluster` to ignore `mesh` configuration for `mode: multicast` which cause an error
 
 0.1.6 (26/05/2015)
 ------------------
 
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add RHEL7 support, after [last Aerospike release](http://www.aerospike.com/download/server/notes.html#3.8.2.1)
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add Ubuntu-14.04 support
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update kitchen config
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add integration tests for old (3.6.3) and latest (3.8.2.3)
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update kitchen test to docker
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Update travis-ci to use docker
+- [Oleksandr Sakharchuk](https://github.com/pioneerit):
+  - Add RHEL7 support, after [last Aerospike release](http://www.aerospike.com/download/server/notes.html#3.8.2.1)
+  - Add Ubuntu-14.04 support
+  - Update kitchen config
+  - Add integration tests for old (3.6.3) and latest (3.8.2.3)
+  - Update kitchen test to docker
+  - Update travis-ci to use docker
 
 0.1.5 (11/05/2016)
 ------------------
 
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fix foodcritic
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fix a typo with attribure for package_url
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Added user cookbook as dependency
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fix travis and typo
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Add atrribute to disable cheksum checking
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Added support for amc version attribute
-
-- [Oleksandr Sakharchuk](https://github.com/pioneerit) - Fixed recipes dependencies
+- [Oleksandr Sakharchuk](https://github.com/pioneerit):
+  - Fix foodcritic
+  - Fix a typo with attribure for package_url
+  - Added user cookbook as dependency
+  - Fix travis and typo
+  - Add atrribute to disable cheksum checking
+  - Added support for amc version attribute
+  - Fixed recipes dependencies
 
 0.1.3 (28/12/2015)
 ------------------
 
-- Blair Hamilton - adding clustering via chef server
+- [Blair Hamilton](https://github.com/blairham) - adding clustering via chef server
 
-- Virender Khatri - #10, fix enable_test_namespace config disable for test namespace
-
-- Virender Khatri - better namespace formatting
-
-- Virender Khatri - fix rubocop #14
+- [Virender Khatri](https://github.com/vkhatri):
+  - #10, fix enable_test_namespace config disable for test namespace
+  - better namespace formatting
+  - fix rubocop #14
 
 0.1.2 (31/10/2015)
 ------------------
 
-- Virender Khatri - #7, added enterprise edition support
-
-- Virender Khatri - #4, added amc setup
-
-- Virender Khatri - #3, make test namespace setup optional
+- [Virender Khatri](https://github.com/vkhatri):
+  - #7, added enterprise edition support
+  - #4, added amc setup
+  - #3, make test namespace setup optional
 
 0.1.1 (26/10/2015)
 ------------------
 
-- Virender Khatri - #1, added package installation support
+- [Virender Khatri](https://github.com/vkhatri) - #1, added package installation support
 
 0.1.0 (24/10/2015)
 ------------------
 
-- Virender Khatri - Initial release of aerospike-cluster
+- [Virender Khatri](https://github.com/vkhatri) - Initial release of aerospike-cluster
 
 - - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a [Chef] cookbook to manage [Aerospike].
 ### Most Recent Release
 
 ```
-cookbook 'aerospike-cluster', '~> 0.1.7'
+cookbook 'aerospike-cluster'
 ```
 
 ### From Git

--- a/Rakefile
+++ b/Rakefile
@@ -38,21 +38,26 @@ end
 begin
   require 'kitchen/rake_tasks'
   Kitchen::RakeTasks.new
-  namespace "kitchen" do
-    desc "run multicast tests"
-    task :multicast do
-      system('bundle exec kitchen converge --concurrency 2 multicast')
-      system('bundle exec kitchen verify --concurrency 2 multicast')
-      system('bundle exec kitchen destroy multicast')
-    end
-    desc "run default tests"
-    task :default do
-      system('bundle exec kitchen test default')
-    end
-    desc 'Run all test suites'
-    task :all_suites => %w(kitchen:default kitchen:multicast)
-  end
 rescue LoadError
   puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
 end
+
+namespace 'kitchen' do
+  desc 'run default tests'
+  task :default do
+    instances = Kitchen::Config.new.instances.select { |instance| instance.name.include?('default') }
+
+    instances.map(&:test)
+  end
+
+  desc 'Run multicast tests'
+  task :multicast do
+    instances = Kitchen::Config.new.instances.select { |instance| instance.name.include?('multicast') }
+
+    instances.map(&:converge)
+    instances.map(&:verify)
+    instances.map(&:destroy)
+  end
+end
+
 

--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,9 @@ namespace 'kitchen' do
     instances.map(&:verify)
     instances.map(&:destroy)
   end
+
+  desc 'Run all test suites'
+  task :all_suites => %w(kitchen:default kitchen:multicast)
 end
 
 

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -25,7 +25,6 @@ default['aerospike']['config']['network']['service']['port'] = 3000
 default['aerospike']['config']['network']['heartbeat']['mode'] = 'mesh'
 default['aerospike']['config']['network']['heartbeat']['address'] = node['ipaddress']
 default['aerospike']['config']['network']['heartbeat']['port'] = 3002
-default['aerospike']['config']['network']['heartbeat']['mesh-seed-address-port'] = ["#{node['ipaddress']} #{node['aerospike']['config']['network']['heartbeat']['port']}"]
 default['aerospike']['config']['network']['heartbeat']['interval'] = 150
 default['aerospike']['config']['network']['heartbeat']['timeout'] = 10
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,3 +11,13 @@ version '0.1.7'
 %w(ubuntu centos amazon redhat fedora).each do |os|
   supports os
 end
+
+recipe 'aerospike-cluster', 'Aerospike installatoin and default installation. Includes repices: attributes, install, config'
+recipe 'aerospike-cluster::attributes', 'Aerospike derived attributes'
+recipe 'aerospike-cluster::install', 'Install aerospike'
+recipe 'aerospike-cluster::user', 'Setup aerospike user'
+recipe 'aerospike-cluster::tarball', 'Aerospike tarball installation'
+recipe 'aerospike-cluster::package', 'Aerospike package installation'
+recipe 'aerospike-cluster::amc', 'Install and configure aerospike management console'
+recipe 'aerospike-cluster::config', 'Configure Aerospike'
+recipe 'aerospike-cluster::cluster', 'Uses chef search if configured to derive value for attribute `default[\'aerospike\'][\'config\'][\'network\'][\'heartbeat\'][\'mesh-seed-address-port\']`'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures aerospike-cluster'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vkhatri/chef-aerospike-cluster/issues'
 source_url 'https://github.com/vkhatri/chef-aerospike-cluster'
-version '0.1.7'
+version '0.1.8'
 
 %w(ubuntu centos amazon redhat fedora).each do |os|
   supports os

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -22,17 +22,19 @@
 
 case node['aerospike']['config']['network']['heartbeat']['mode']
 when 'mesh'
-  if Chef::Config[:solo]
+  if Chef::Config[:solo] && !node['aerospike']['chef']['search'].to_s.empty?
     Chef::Log.warn 'This recipe uses search. Chef Solo does not support search.'
     raise '[ERROR] Can\'t configure aerospike cluster. Chef Solo does not support search.'
   end
   if node['aerospike']['chef']['search'].to_s.empty?
-    raise "[ERROR] Can't configure aerospike cluster, node['aerospike']['chef']['search'] is empty."
+    node.default['aerospike']['config']['network']['heartbeat']['mesh-seed-address-port'] = ["#{node['ipaddress']} #{node['aerospike']['config']['network']['heartbeat']['port']}"] if node['aerospike']['config']['network']['heartbeat']['mesh-seed-address-port'].empty?
   else
     nodes = search(:node, node['aerospike']['chef']['search'].to_s)
-  end
-  nodes.sort_by! { |n| n['ipaddress'] }
-  nodes.map! { |n| "#{n['ipaddress']} #{n['aerospike']['config']['network']['heartbeat']['port']}" }
 
-  node.default['aerospike']['config']['network']['heartbeat']['mesh-seed-address-port'] = nodes
+    nodes.sort_by! { |n| n['ipaddress'] }
+    nodes.map! { |n| "#{n['ipaddress']} #{n['aerospike']['config']['network']['heartbeat']['port']}" }
+
+    node.default['aerospike']['config']['network']['heartbeat']['mesh-seed-address-port'] = nodes
+  end
+
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -50,6 +50,7 @@ end
 service 'aerospike' do
   supports :restart => true, :start => true, :stop => true, :status => true, :reload => false
   action node['aerospike']['service_action']
+  notifies :restart, 'service[amc]', :immediately
   case node['platform']
   when 'centos'
     if node['platform_version'].to_f >= 7

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -26,7 +26,7 @@
   node['aerospike']['config']['mod-lua']['user-path'],
   node['aerospike']['config']['mod-lua']['system-path'],
   node['aerospike']['config']['service']['work-directory']
-].each do |d|
+].uniq.each do |d|
   directory d do
     owner node['aerospike']['user']
     group node['aerospike']['group']

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -50,6 +50,7 @@ package_checksum = package_sha256sum(node['aerospike']['install_edition'], node[
 
 # download tarball
 remote_file "Download #{package_file}" do
+  path package_file
   source package_url
   checksum package_checksum if node['aerospike']['checksum_verify']
   headers('Authorization' => "Basic #{Base64.encode64("#{node['aerospike']['enterprise']['username']}:#{node['aerospike']['enterprise']['password']}").delete("\n")}") if node['aerospike']['install_edition'] == 'enterprise'
@@ -69,6 +70,7 @@ execute 'extract_aerospike_package' do
 end
 
 remote_file "Delete #{package_file}" do
+  path package_file
   action :delete
 end
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -49,7 +49,7 @@ package_file = ::File.join(node['aerospike']['parent_dir'], "aerospike-server-#{
 package_checksum = package_sha256sum(node['aerospike']['install_edition'], node['aerospike']['version'], node['aerospike']['package_suffix']) if node['aerospike']['checksum_verify']
 
 # download tarball
-remote_file package_file do
+remote_file "Download #{package_file}" do
   source package_url
   checksum package_checksum if node['aerospike']['checksum_verify']
   headers('Authorization' => "Basic #{Base64.encode64("#{node['aerospike']['enterprise']['username']}:#{node['aerospike']['enterprise']['password']}").delete("\n")}") if node['aerospike']['install_edition'] == 'enterprise'
@@ -68,7 +68,7 @@ execute 'extract_aerospike_package' do
   creates ::File.join(node['aerospike']['source_dir'], 'asinstall')
 end
 
-remote_file package_file do
+remote_file "Delete #{package_file}" do
   action :delete
 end
 

--- a/test/integration/multicast/serverspec/default_spec.rb
+++ b/test/integration/multicast/serverspec/default_spec.rb
@@ -10,7 +10,7 @@ describe 'fyber_aerospike::default' do
       it { should be_listening.with('tcp') }
     end
   end
-  describe port(9918) do
+  describe port(3002) do
     it { should be_listening.with('udp') }
   end
   describe command('asinfo -v statistics -l | grep cluster_size') do


### PR DESCRIPTION
- Remove cloning resource attributes from prior resource (CHEF-3694)
- Permanent fix for [#8](https://github.com/vkhatri/chef-aerospike-cluster/issues/8) - remote_file for enterprise edition with authentication
- After PR [#12](https://github.com/vkhatri/chef-aerospike-cluster/pull/12) attribute `mesh-seed-address-port` not needed.
- Update cluster.rb recipe for default value and support chef-solo if possible
- Restart `amc` applicatoin if `aerospike` was restarted
- Update tests and rake's tasks
